### PR TITLE
chore: pylintをルートディレクトリ上から有効にする #6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Run pylint on all Python files
       run: |
-        find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" -print0 | xargs -0 -r pylint
+        find . \( -path "./.git" -o -path "./__pycache__" -o -path "*/__pycache__" -o -path "*/venv" -o -path "*/env" -o -path "*/.venv" \) -prune -o -name "*.py" -print0 | xargs -0 -r pylint
 
     - name: Run pytest
       run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,11 +31,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run pylint on templates
-      run: pylint templates/
-
-    - name: Run pylint on utils
-      run: pylint utils/
+    - name: Run pylint on all Python files
+      run: |
+        if find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" | grep -q .; then
+          pylint $(find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*")
+        else
+          echo "No Python files found, skipping pylint"
+        fi
 
     - name: Run pytest
       run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,8 +33,8 @@ jobs:
 
     - name: Run pylint on all Python files
       run: |
-        if find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" | grep -q .; then
-          find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -print0 | xargs -0 pylint
+        if find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" | grep -q .; then
+          find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" -print0 | xargs -0 pylint
         else
           echo "No Python files found, skipping pylint"
         fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run pylint on all Python files
       run: |
         if find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" | grep -q .; then
-          pylint $(find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*")
+          find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -print0 | xargs -0 pylint
         else
           echo "No Python files found, skipping pylint"
         fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,11 +33,7 @@ jobs:
 
     - name: Run pylint on all Python files
       run: |
-        if find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" | grep -q .; then
-          find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" -print0 | xargs -0 pylint
-        else
-          echo "No Python files found, skipping pylint"
-        fi
+        find . -name "*.py" -not -path "./.git/*" -not -path "./__pycache__/*" -not -path "*/__pycache__/*" -not -path "*/venv/*" -not -path "*/env/*" -not -path "*/.venv/*" -print0 | xargs -0 -r pylint
 
     - name: Run pytest
       run: |


### PR DESCRIPTION
# Issue
resolves #6

# Summary
GitHub ActionsのワークフローファイルでPythonファイルのlintingを段階的に改善しました：
- ファイル名にスペースが含まれる場合の適切な処理（`find -print0 | xargs -0`）
- 仮想環境ディレクトリの除外（venv、env、.venv）
- 重複するfindコマンドの削除（`xargs -r`による効率化）
- ディレクトリトラバーサルの最適化（`-prune`により不要なディレクトリを完全回避）

# Commits
- **04cd1e0** fix: 不要なディレクトリ参照をしないように修正 (anecdotes, 2025-06-29)
- **95b2e04** fix: 重複処理の削除 (anecdotes, 2025-06-29)
- **21e5b1a** fix: PythonライブラリをLint対象に含めない (anecdotes, 2025-06-29)
- **a4e181c** fix: スペースを適切に処理できない問題 (anecdotes, 2025-06-29)
- **09db166** fix: workflow (anecdotes, 2025-06-28)
